### PR TITLE
Fix linking on OpenBSD

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,8 +2,8 @@
 
 {port_env, [ %% Make sure to link -lstdc++ on linux or solaris
              {"(linux|solaris)", "LDFLAGS", "$LDFLAGS -lstdc++"},
-             %% Make sure to link directly on linux
-             {"(linux)", "ERL_LDFLAGS", "$LDFLAGS $ERL_LDFLAGS -lcrypto"},
+             %% Make sure to link directly on linux or openbsd
+             {"(linux|openbsd)", "ERL_LDFLAGS", "$LDFLAGS $ERL_LDFLAGS -lcrypto"},
              %% OS X Leopard flags for 64-bit
              {"darwin9.*-64$", "CXXFLAGS", "-m64"},
              {"darwin9.*-64$", "LDFLAGS", "-arch x86_64"},


### PR DESCRIPTION
This commit let's chef_certgen correctly link on OpenBSD.
