### PR TITLE
Add upgrade to chef_certgen NIF
    
Without an upgrade function, we see the following error report
when

### DIFF
--- a/c_src/chef_certgen.c
+++ b/c_src/chef_certgen.c
@@ -73,6 +73,7 @@ static const EVP_MD *digest;
 
 /* NIF interface declarations */
 static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info);
+static int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data, ERL_NIF_TERM load_info);
 
 static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
 {
@@ -89,6 +90,13 @@ static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
     atom_ok = enif_make_atom(env,"ok");
     atom_x509_cert = enif_make_atom(env, "x509_cert");
 
+    return 0;
+}
+
+static int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data,
+                   ERL_NIF_TERM load_info)
+{
+    load(env, priv_data, load_info);
     return 0;
 }
 
@@ -511,4 +519,4 @@ static ERL_NIF_TERM x509_make_cert_nif(ErlNifEnv* env, int argc, const ERL_NIF_T
   return ret;
 }
 
-ERL_NIF_INIT(chef_certgen,nif_funcs,load,NULL,NULL,NULL)
+ERL_NIF_INIT(chef_certgen,nif_funcs,load,NULL,upgrade,NULL)


### PR DESCRIPTION
running the unit tests:

```
=ERROR REPORT==== 11-Mar-2013::10:22:45 ===
The on_load function for module chef_certgen returned
{error,
 {upgrade, "Upgrade not supported by this NIF library."}}
```

Adding upgrade that is identical to load resolves it
